### PR TITLE
Feature/improve tests

### DIFF
--- a/Crc32.NET.Tests/BytePatternsTest.cs
+++ b/Crc32.NET.Tests/BytePatternsTest.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Linq;
+using Force.Crc32.Tests.Crc32Implementations;
+using NUnit.Framework;
+
+namespace Force.Crc32.Tests
+{
+    [TestFixture]
+    public class BytePatternsTest
+    {
+        [Test]
+        public void Crc32ForEmptySequenseIs0()
+        {
+            var actual = Crc32Algorithm.Compute(new byte[0]);
+            Assert.That(actual, Is.EqualTo(0));
+        }
+        
+        // Pattern: 
+        // xx
+        // xx xx
+        // xx xx xx
+        // ...
+        [Test]
+        public void RepeatedBytePatternTest()
+        {
+            foreach (byte x in Enumerable.Range(0, 256))
+            {
+                foreach (int len in Enumerable.Range(1, 32))
+                {
+                    var data = Enumerable.Repeat(x, len).ToArray();
+                    TestByteSequence(data);
+                }
+            }
+        }
+
+        // Pattern:
+        // xx
+        // xx 00
+        // 00 xx
+        // xx 00 00
+        // 00 xx 00
+        // 00 00 xx
+        // ...
+        
+        // xx
+        // xx FF
+        // FF xx
+        // xx FF FF
+        // FF xx FF
+        // FF FF xx
+        // ...
+        [TestCase(0x00)]
+        [TestCase(0xFF)]
+        public void SlidingBytePatternTest(byte fillValue)
+        {
+            foreach (int len in Enumerable.Range(1, 32))
+            {
+                var data = Enumerable.Repeat(fillValue, len).ToArray();
+
+                foreach (var i in Enumerable.Range(0, len))
+                {
+                    foreach (byte x in Enumerable.Range(0, 256))
+                    {
+                        data[i] = x;
+                        TestByteSequence(data);
+                    }
+
+                    data[i] = fillValue;
+                }
+            }
+        }
+
+        private void TestByteSequence(byte[] data)
+        {
+            var actual = Crc32Algorithm.Compute(data);
+            var expected = _referenceImplementation.Calculate(data);
+
+            if (expected != actual)
+            {
+                var message = string.Format("Test failed for {0}\nExpected: {1:x8}\nBut was: {2:x8}",
+                    BitConverter.ToString(data), expected, actual);
+                Assert.Fail(message);
+            }
+        }
+
+        private readonly CrcCalculator _referenceImplementation = new System_Data_HashFunction_CRC();
+    }
+}

--- a/Crc32.NET.Tests/Crc32.NET.Tests.csproj
+++ b/Crc32.NET.Tests/Crc32.NET.Tests.csproj
@@ -63,6 +63,13 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BytePatternsTest.cs" />
+    <Compile Include="Crc32Implementations\CH_Crc32_Crc.cs" />
+    <Compile Include="Crc32Implementations\Crc32_Crc32Algorithm.cs" />
+    <Compile Include="Crc32Implementations\CrcCalculator.cs" />
+    <Compile Include="Crc32Implementations\Force_Crc32_Crc32Algorithm.cs" />
+    <Compile Include="Crc32Implementations\Klinkby_Checkum_Crc32.cs" />
+    <Compile Include="Crc32Implementations\System_Data_HashFunction_CRC.cs" />
     <Compile Include="PerformanceTest.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Crc32.NET.Tests/Crc32Implementations/CH_Crc32_Crc.cs
+++ b/Crc32.NET.Tests/Crc32Implementations/CH_Crc32_Crc.cs
@@ -1,0 +1,14 @@
+﻿namespace Force.Crc32.Tests.Crc32Implementations
+{
+    class CH_Crc32_Crc : CrcCalculator
+    {
+        public CH_Crc32_Crc() : base("CH.Crc32.Crc")
+        {
+        }
+
+        public override uint Calculate(byte[] data)
+        {
+            return CH.Crc32.Crc.Crc32(data);
+        }
+    }
+}

--- a/Crc32.NET.Tests/Crc32Implementations/Crc32_Crc32Algorithm.cs
+++ b/Crc32.NET.Tests/Crc32Implementations/Crc32_Crc32Algorithm.cs
@@ -1,0 +1,16 @@
+﻿using Crc = Crc32.Crc32Algorithm;
+
+namespace Force.Crc32.Tests.Crc32Implementations
+{
+    class Crc32_Crc32Algorithm : CrcCalculator
+    {
+        public Crc32_Crc32Algorithm() : base("Crc32.Crc32Algorithm")
+        {
+        }
+
+        public override uint Calculate(byte[] data)
+        {
+            return Crc.Compute(data);
+        }
+    }
+}

--- a/Crc32.NET.Tests/Crc32Implementations/CrcCalculator.cs
+++ b/Crc32.NET.Tests/Crc32Implementations/CrcCalculator.cs
@@ -1,0 +1,14 @@
+﻿namespace Force.Crc32.Tests.Crc32Implementations
+{
+    abstract class CrcCalculator
+    {
+        protected CrcCalculator(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; private set; }
+
+        public abstract uint Calculate(byte[] data);
+    }
+}

--- a/Crc32.NET.Tests/Crc32Implementations/Force_Crc32_Crc32Algorithm.cs
+++ b/Crc32.NET.Tests/Crc32Implementations/Force_Crc32_Crc32Algorithm.cs
@@ -1,0 +1,14 @@
+﻿namespace Force.Crc32.Tests.Crc32Implementations
+{
+    class Force_Crc32_Crc32Algorithm : CrcCalculator
+    {
+        public Force_Crc32_Crc32Algorithm() : base("Force.Crc32.Crc32Algorithm")
+        {
+        }
+
+        public override uint Calculate(byte[] data)
+        {
+            return Force.Crc32.Crc32Algorithm.Compute(data);
+        }
+    }
+}

--- a/Crc32.NET.Tests/Crc32Implementations/Klinkby_Checkum_Crc32.cs
+++ b/Crc32.NET.Tests/Crc32Implementations/Klinkby_Checkum_Crc32.cs
@@ -1,0 +1,14 @@
+﻿namespace Force.Crc32.Tests.Crc32Implementations
+{
+    class Klinkby_Checkum_Crc32 : CrcCalculator
+    {
+        public Klinkby_Checkum_Crc32() : base("Klinkby.Checkum.Crc32")
+        {
+        }
+
+        public override uint Calculate(byte[] data)
+        {
+            return (uint)Klinkby.Checkum.Crc32.ComputeChecksum(data);
+        }
+    }
+}

--- a/Crc32.NET.Tests/Crc32Implementations/System_Data_HashFunction_CRC.cs
+++ b/Crc32.NET.Tests/Crc32Implementations/System_Data_HashFunction_CRC.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Data.HashFunction;
+
+namespace Force.Crc32.Tests.Crc32Implementations
+{
+    class System_Data_HashFunction_CRC : CrcCalculator
+    {
+        public System_Data_HashFunction_CRC() : base("System.Data.HashFunction.CRC")
+        {
+            _crc = new CRC();
+        }
+
+        public override uint Calculate(byte[] data)
+        {
+            return BitConverter.ToUInt32(_crc.ComputeHash(data), 0);
+        }
+
+        private CRC _crc;
+    }
+}

--- a/Crc32.NET.Tests/ImplementationTest.cs
+++ b/Crc32.NET.Tests/ImplementationTest.cs
@@ -26,16 +26,6 @@ namespace Force.Crc32.Tests
 		}
 
 		[Test]
-		public void ResultConsistencyLong()
-		{
-			var bytes = new byte[30000];
-			new Random().NextBytes(bytes);
-			var crc1 = (uint)BitConverter.ToInt32(new E().ComputeHash(bytes, 0, bytes.Length), 0);
-			var crc2 = Crc32Algorithm.Append(0, bytes, 0, bytes.Length);
-			Assert.That(crc2, Is.EqualTo(crc1));
-		}
-
-		[Test]
 		public void ResultConsistency2()
 		{
 			Assert.That(Crc32Algorithm.Compute(new byte[] { 1 }), Is.EqualTo(2768625435));
@@ -61,7 +51,6 @@ namespace Force.Crc32.Tests
 		{
 			var bytes = new byte[30000];
 			new Random().NextBytes(bytes);
-			var c = new Crc32Algorithm();
 			var r1 = Crc32Algorithm.Append(0, bytes, 0, 15000);
 			var r2 = Crc32Algorithm.Append(r1, bytes, 15000, 15000);
 			var r3 = Crc32Algorithm.Append(0, bytes, 0, 30000);

--- a/Crc32.NET.Tests/PerformanceTest.cs
+++ b/Crc32.NET.Tests/PerformanceTest.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Data.HashFunction;
 using System.Diagnostics;
-
+using Force.Crc32.Tests.Crc32Implementations;
 using NUnit.Framework;
-
-using E = Crc32.Crc32Algorithm;
 
 namespace Force.Crc32.Tests
 {
@@ -14,98 +11,54 @@ namespace Force.Crc32.Tests
 		[Test]
 		public void ThroughputCHCrc32_By_tanglebones()
 		{
-			var data = new byte[65536];
-			var random = new Random();
-			random.NextBytes(data);
-			long total = 0;
-			var stopwatch = new Stopwatch();
-			stopwatch.Start();
-			while (stopwatch.Elapsed < TimeSpan.FromSeconds(3))
-			{
-				CH.Crc32.Crc.Crc32(data);
-				total += data.Length;
-			}
-
-			stopwatch.Stop();
-			Console.WriteLine("Throughput: {0:0.0} MB/s", total / stopwatch.Elapsed.TotalSeconds / 1024 / 1024);
-		}
+            Calculate(new CH_Crc32_Crc());
+        }
 
 		[Test]
 		public void ThroughputKlinkby_Checksum()
 		{
-			var data = new byte[65536];
-			var random = new Random();
-			random.NextBytes(data);
-			long total = 0;
-			var stopwatch = new Stopwatch();
-			stopwatch.Start();
-			while (stopwatch.Elapsed < TimeSpan.FromSeconds(3))
-			{
-				Klinkby.Checkum.Crc32.ComputeChecksum(data);
-				total += data.Length;
-			}
-
-			stopwatch.Stop();
-			Console.WriteLine("Throughput: {0:0.0} MB/s", total / stopwatch.Elapsed.TotalSeconds / 1024 / 1024);
+			Calculate(new Klinkby_Checkum_Crc32());
 		}
 
 		[Test]
 		public void ThroughputCrc32_By_dariogriffo()
 		{
-			var data = new byte[65536];
-			var random = new Random();
-			random.NextBytes(data);
-			long total = 0;
-			var stopwatch = new Stopwatch();
-			stopwatch.Start();
-			while (stopwatch.Elapsed < TimeSpan.FromSeconds(3))
-			{
-				E.Compute(data);
-				total += data.Length;
-			}
-
-			stopwatch.Stop();
-			Console.WriteLine("Throughput: {0:0.0} MB/s", total / stopwatch.Elapsed.TotalSeconds / 1024 / 1024);
+			Calculate(new Crc32_Crc32Algorithm());
 		}
 
 		[Test]
 		public void ThroughputCrc32_By_Data_HashFunction_Crc()
 		{
-			var data = new byte[65536];
-			var random = new Random();
-			random.NextBytes(data);
-			var crc = new CRC();
-			long total = 0;
-			var stopwatch = new Stopwatch();
-			stopwatch.Start();
-			while (stopwatch.Elapsed < TimeSpan.FromSeconds(3))
-			{
-				crc.ComputeHash(data);
-				total += data.Length;
-			}
-
-			stopwatch.Stop();
-			Console.WriteLine("Throughput: {0:0.0} MB/s", total / stopwatch.Elapsed.TotalSeconds / 1024 / 1024);
+			Calculate(new System_Data_HashFunction_CRC());
 		}
 
 		[Test]
 		public void ThroughputCrc32_By_Me()
 		{
-			var data = new byte[65536];
-			var random = new Random();
-			random.NextBytes(data);
-			long total = 0;
-
-			var stopwatch = new Stopwatch();
-			stopwatch.Start();
-			while (stopwatch.Elapsed < TimeSpan.FromSeconds(3))
-			{
-				Crc32Algorithm.Compute(data);
-				total += data.Length;
-			}
-
-			stopwatch.Stop();
-			Console.WriteLine("Throughput: {0:0.0} MB/s", total / stopwatch.Elapsed.TotalSeconds / 1024 / 1024);
+			Calculate(new Force_Crc32_Crc32Algorithm());
 		}
-	}
+
+        private void Calculate(CrcCalculator implementation)
+        {
+            var data = new byte[65536];
+            var random = new Random();
+            random.NextBytes(data);
+            long total = 0;
+
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            while (stopwatch.Elapsed < TimeSpan.FromSeconds(3))
+            {
+                implementation.Calculate(data);
+                total += data.Length;
+            }
+
+            stopwatch.Stop();
+
+            Console.WriteLine("{0} Throughput: {1:0.0} MB/s",
+                implementation.Name,
+                total / stopwatch.Elapsed.TotalSeconds / 1024 / 1024);
+        }
+    }
 }

--- a/Crc32.NET.Tests/Program.cs
+++ b/Crc32.NET.Tests/Program.cs
@@ -7,8 +7,9 @@
 			var pt = new PerformanceTest();
 			pt.ThroughputCrc32_By_dariogriffo();
 			pt.ThroughputCHCrc32_By_tanglebones();
+            pt.ThroughputKlinkby_Checksum();
 			pt.ThroughputCrc32_By_Data_HashFunction_Crc();
 			pt.ThroughputCrc32_By_Me();
-		}
-	}
+        }
+    }
 }


### PR DESCRIPTION
ResultConsistencyLong test was failing because of little endian - big endian mismatch. I removed it because ResultConsistencyAsHashAlgorithm test is almost identical.

I Added a class for every CRC32 implementations used in performance tests with CrcCalculator as a base abstract class. This simplifies performance tests and removes code duplication.

BytePatternsTest tests some generated byte sequences. The calculated checksum is compared to another algorithm implementation.
