### PR TITLE
Speed up.

### DIFF
--- a/Crc32.NET/SafeProxy.cs
+++ b/Crc32.NET/SafeProxy.cs
@@ -30,7 +30,7 @@ namespace Force.Crc32
 				for (int t = 0; t < 16; t++)
 				{
 					for (int k = 0; k < 8; k++) res = (res & 1) == 1 ? poly ^ (res >> 1) : (res >> 1);
-					table[(t * 256) + i] = res;
+					table[(t << 8) + i] = res;
 				}
 			}
 		}
@@ -42,33 +42,33 @@ namespace Force.Crc32
 			uint[] table = _table;
 			while (length >= 16)
 			{
-				var a = table[(3 * 256) + input[offset + 12]]
-					^ table[(2 * 256) + input[offset + 13]]
-					^ table[(1 * 256) + input[offset + 14]]
-					^ table[(0 * 256) + input[offset + 15]];
+                
+                var d = table[(15 * 8) + ((byte)crcLocal ^ input[offset++])]
+                    ^ table[(14 * 8) + ((byte)(crcLocal >> 8) ^ input[offset++])]
+                    ^ table[(13 * 8) + ((byte)(crcLocal >> 16) ^ input[offset++])]
+                    ^ table[(12 * 8) + ((crcLocal >> 24) ^ input[offset++])];
 
-				var b = table[(7 * 256) + input[offset + 8]]
-					^ table[(6 * 256) + input[offset + 9]]
-					^ table[(5 * 256) + input[offset + 10]]
-					^ table[(4 * 256) + input[offset + 11]];
+                var c = table[(11 * 8) + input[offset++]]
+                    ^ table[(10 * 8) + input[offset++]]
+                    ^ table[(9 * 8) + input[offset++]]
+                    ^ table[(8 * 8) + input[offset++]];
 
-				var c = table[(11 * 256) + input[offset + 4]] 
-					^ table[(10 * 256) + input[offset + 5]] 
-					^ table[(9 * 256) + input[offset + 6]] 
-					^ table[(8 * 256) + input[offset + 7]];
-
-				var d = table[(15 * 256) + ((crcLocal ^ input[offset]) & 0xff)]
-					^ table[(14 * 256) + (((crcLocal >> 8) ^ input[offset + 1]) & 0xff)]
-					^ table[(13 * 256) + (((crcLocal >> 16) ^ input[offset + 2]) & 0xff)]
-					^ table[(12 * 256) + (((crcLocal >> 24) ^ input[offset + 3]) & 0xff)];
-
+                var b = table[(7 * 8) + input[offset++]]
+                    ^ table[(6 * 8) + input[offset++]]
+                    ^ table[(5 * 8) + input[offset++]]
+                    ^ table[(4 * 8) + input[offset++]];
+                                 
+                var a = table[(3 * 8) + input[offset++]]
+                    ^ table[(2 * 8) + input[offset++]]
+                    ^ table[256 + input[offset++]] //1 * 256
+                    ^ table[input[offset++]]; //0 * 256
+              
 				crcLocal = d ^ c ^ b ^ a;
-				offset += 16;
 				length -= 16;
 			}
 
 			while (--length >= 0)
-				crcLocal = table[(crcLocal ^ input[offset++]) & 0xff] ^ crcLocal >> 8;
+				crcLocal = table[(byte)(crcLocal ^ input[offset++])] ^ crcLocal >> 8;
 
 			return crcLocal ^ uint.MaxValue;
 		}


### PR DESCRIPTION
For each 16 bytes:
- Change 16 sums (+) for increments (++). Increment are faster then sum.
- Erase 1 subtract
- Erase (1* 256) and (0*256). Perhaps the compiler optimize this operations.


In precalc table
Change one mult for one rotare right. (Only 16536 operations per execution.)

In my test speed up 8%