### PR TITLE
Added Stream functionality

### DIFF
--- a/Crc32.NET/SafeProxy.cs
+++ b/Crc32.NET/SafeProxy.cs
@@ -8,67 +8,77 @@
  * Max Vysokikh, 2016-2017
  */
 
+using System.IO;
+
 namespace Force.Crc32
 {
 	internal class SafeProxy
 	{
 		private const uint Poly = 0xedb88320u;
 
-		private readonly uint[] _table = new uint[16 * 256];
+		private readonly uint[] _table;
 
 		internal SafeProxy()
 		{
-			Init(Poly);
+            _table = CreateTable(Poly);
 		}
 
-		protected void Init(uint poly)
+        internal SafeProxy(uint poly)
+        {
+            _table = CreateTable(poly);
+        }
+
+        protected uint[] CreateTable(uint poly)
+        {
+            var table = new uint[16 * 256];
+            for (uint i = 0; i < 256; i++)
+            {
+                uint res = i;
+                for (int t = 0; t < 16; t++)
+                {
+                    for (int k = 0; k < 8; k++) res = (res & 1) == 1 ? poly ^ (res >> 1) : (res >> 1);
+                    table[(t * 256) + i] = res;
+                }
+            }
+
+            return table;
+        }
+
+        public uint Append(uint crc, Stream input)
 		{
-			var table = _table;
-			for (uint i = 0; i < 256; i++)
-			{
-				uint res = i;
-				for (int t = 0; t < 16; t++)
-				{
-					for (int k = 0; k < 8; k++) res = (res & 1) == 1 ? poly ^ (res >> 1) : (res >> 1);
-					table[(t * 256) + i] = res;
-				}
-			}
-		}
+			var crcLocal = uint.MaxValue ^ crc;
+            var data = new byte[16];
+            int readLength;
 
-		public uint Append(uint crc, byte[] input, int offset, int length)
-		{
-			uint crcLocal = uint.MaxValue ^ crc;
+            input.Seek(0, SeekOrigin.Begin);
 
-			uint[] table = _table;
-			while (length >= 16)
-			{
-				var a = table[(3 * 256) + input[offset + 12]]
-					^ table[(2 * 256) + input[offset + 13]]
-					^ table[(1 * 256) + input[offset + 14]]
-					^ table[(0 * 256) + input[offset + 15]];
+            while ((readLength = input.Read(data, 0, 16)) == 16)
+            {
+				var a = _table[(3 * 256) + data[12]]
+					^ _table[(2 * 256) + data[13]]
+					^ _table[(1 * 256) + data[14]]
+					^ _table[(0 * 256) + data[15]];
 
-				var b = table[(7 * 256) + input[offset + 8]]
-					^ table[(6 * 256) + input[offset + 9]]
-					^ table[(5 * 256) + input[offset + 10]]
-					^ table[(4 * 256) + input[offset + 11]];
+				var b = _table[(7 * 256) + data[8]]
+					^ _table[(6 * 256) + data[9]]
+					^ _table[(5 * 256) + data[10]]
+					^ _table[(4 * 256) + data[11]];
 
-				var c = table[(11 * 256) + input[offset + 4]] 
-					^ table[(10 * 256) + input[offset + 5]] 
-					^ table[(9 * 256) + input[offset + 6]] 
-					^ table[(8 * 256) + input[offset + 7]];
+				var c = _table[(11 * 256) + data[4]] 
+					^ _table[(10 * 256) + data[5]] 
+					^ _table[(9 * 256) + data[6]] 
+					^ _table[(8 * 256) + data[7]];
 
-				var d = table[(15 * 256) + ((byte)crcLocal ^ input[offset])]
-					^ table[(14 * 256) + ((byte)(crcLocal >> 8) ^ input[offset + 1])]
-					^ table[(13 * 256) + ((byte)(crcLocal >> 16) ^ input[offset + 2])]
-					^ table[(12 * 256) + ((crcLocal >> 24) ^ input[offset + 3])];
+				var d = _table[(15 * 256) + ((byte)crcLocal ^ data[0])]
+					^ _table[(14 * 256) + ((byte)(crcLocal >> 8) ^ data[1])]
+					^ _table[(13 * 256) + ((byte)(crcLocal >> 16) ^ data[2])]
+					^ _table[(12 * 256) + ((crcLocal >> 24) ^ data[3])];
 
 				crcLocal = d ^ c ^ b ^ a;
-				offset += 16;
-				length -= 16;
 			}
-
-			while (--length >= 0)
-				crcLocal = table[(byte)(crcLocal ^ input[offset++])] ^ crcLocal >> 8;
+            
+            for (var i = 0; i < readLength; i++)
+                crcLocal = _table[(byte)(crcLocal ^ data[i])] ^ crcLocal >> 8;
 
 			return crcLocal ^ uint.MaxValue;
 		}

--- a/Crc32.NET/SafeProxyC.cs
+++ b/Crc32.NET/SafeProxyC.cs
@@ -10,9 +10,8 @@ namespace Force.Crc32
 	{
 		private const uint Poly = 0x82F63B78u;
 
-		internal SafeProxyC()
+		internal SafeProxyC() : base(Poly)
 		{
-			Init(Poly);
-		}
+        }
 	}
 }


### PR DESCRIPTION
* Can now call Compute and Append with a Stream
* The field in SafeProxy is now really read-only.
* No unit tests were written for streams since all the current tests already test the Stream.
* With a Stream, you don't need to have offset/length  overload functions since it's already contained in the Stream.
* To Debug the buffer in a MemoryStream, ensure that the last parameter of the constructor is true.