### PR TITLE
Add .NET Core 2.1 and 3.0 perf improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ packages
 .tools
 private.snk
 .idea
+BenchmarkDotNet.Artifacts/

--- a/Crc32.NET.Benchmarks/Crc32.NET.Benchmarks.csproj
+++ b/Crc32.NET.Benchmarks/Crc32.NET.Benchmarks.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Crc32.NET\Crc32.NET.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Crc32.NET.Benchmarks/Crc32.cs
+++ b/Crc32.NET.Benchmarks/Crc32.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using Force.Crc32;
+
+namespace Crc32.NET.Benchmarks
+{
+    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
+    public class Crc32
+    {
+        private byte[] _input;
+        private byte[] _destination;
+
+        [Params(65536)]
+        public int Size { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _input = new byte[Size];
+            var random = new Random();
+            random.NextBytes(_input);
+
+            _destination = new byte[4];
+        }
+
+        [Benchmark(Baseline = true)]
+        public byte[] Array()
+        {
+            var crc = new Crc32Algorithm();
+            return crc.ComputeHash(_input);
+        }
+
+#if NETCOREAPP3_1
+        [Benchmark]
+        public void Span()
+        {
+            var crc = new Crc32Algorithm();
+            crc.TryComputeHash(_input.AsSpan(), _destination.AsSpan(), out _);
+        }
+#endif
+    }
+}

--- a/Crc32.NET.Benchmarks/Program.cs
+++ b/Crc32.NET.Benchmarks/Program.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using BenchmarkDotNet.Running;
+
+namespace Crc32.NET.Benchmarks
+{
+    class Program
+    {
+        static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, new StandardConfig());
+    }
+}

--- a/Crc32.NET.Benchmarks/StandardConfig.cs
+++ b/Crc32.NET.Benchmarks/StandardConfig.cs
@@ -1,0 +1,23 @@
+﻿using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Loggers;
+
+namespace Crc32.NET.Benchmarks
+{
+    public class StandardConfig : ManualConfig
+    {
+        public StandardConfig()
+        {
+            AddColumnProvider(DefaultColumnProviders.Instance);
+            AddColumn(RankColumn.Arabic);
+
+            AddExporter(DefaultExporters.CsvMeasurements);
+            AddExporter(DefaultExporters.Csv);
+            AddExporter(DefaultExporters.Markdown);
+            AddExporter(DefaultExporters.Html);
+
+            AddLogger(ConsoleLogger.Default);
+        }
+    }
+}

--- a/Crc32.NET.Core.sln
+++ b/Crc32.NET.Core.sln
@@ -1,16 +1,18 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26114.2
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30611.23
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Crc32.NET", "Crc32.NET\Crc32.NET.Core.csproj", "{E95FA3F3-4ED0-41FF-9A1F-DE80CE14A976}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Crc32.NET.Core", "Crc32.NET\Crc32.NET.Core.csproj", "{E95FA3F3-4ED0-41FF-9A1F-DE80CE14A976}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Crc32.NET.Tests", "Crc32.NET.Tests\Crc32.NET.Tests.Core.csproj", "{A602A9CA-793A-4096-A93C-799CA74519BF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Crc32.NET.Tests.Core", "Crc32.NET.Tests\Crc32.NET.Tests.Core.csproj", "{A602A9CA-793A-4096-A93C-799CA74519BF}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{56B92A80-3AE8-4FD0-B1F6-3847919216DA}"
 	ProjectSection(SolutionItems) = preProject
 		README.md = README.md
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Crc32.NET.Benchmarks", "Crc32.NET.Benchmarks\Crc32.NET.Benchmarks.csproj", "{13C3DDAD-50F1-4804-95A1-D54766EA1247}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -26,8 +28,15 @@ Global
 		{A602A9CA-793A-4096-A93C-799CA74519BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A602A9CA-793A-4096-A93C-799CA74519BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A602A9CA-793A-4096-A93C-799CA74519BF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{13C3DDAD-50F1-4804-95A1-D54766EA1247}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{13C3DDAD-50F1-4804-95A1-D54766EA1247}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{13C3DDAD-50F1-4804-95A1-D54766EA1247}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{13C3DDAD-50F1-4804-95A1-D54766EA1247}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A1461F74-929C-4C81-8E25-B44498AEEF6D}
 	EndGlobalSection
 EndGlobal

--- a/Crc32.NET.Tests/Crc32.NET.Tests.Core.csproj
+++ b/Crc32.NET.Tests/Crc32.NET.Tests.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0;netcoreapp3.1;net461</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>Crc32.NET.Tests</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -39,6 +39,9 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <DefineConstants>$(DefineConstants);NETCORE;NETCORE20</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <DefineConstants>$(DefineConstants);NETCORE;NETCORE30</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);COREVERSION</DefineConstants>

--- a/Crc32.NET/Crc32.NET.Core.csproj
+++ b/Crc32.NET/Crc32.NET.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <VersionPrefix>1.2.1</VersionPrefix>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;net20</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1;net20</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Crc32.NET</AssemblyName>
     <!--DelaySign>true</DelaySign>
@@ -29,7 +29,13 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);NETCORE;NETCORE20</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <DefineConstants>$(DefineConstants);NETCORE;NETCORE30</DefineConstants>
+  </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
     <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 </Project>

--- a/Crc32.NET/Crc32Algorithm.cs
+++ b/Crc32.NET/Crc32Algorithm.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+#if NETCORE30
+using System.Buffers.Binary;
+#endif
 using System.Security.Cryptography;
 
 namespace Force.Crc32
@@ -14,7 +17,7 @@ namespace Force.Crc32
 		private readonly bool _isBigEndian = true;
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="Crc32Algorithm"/> class. 
+		/// Initializes a new instance of the <see cref="Crc32Algorithm"/> class.
 		/// </summary>
 		public Crc32Algorithm()
 		{
@@ -24,7 +27,7 @@ namespace Force.Crc32
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="Crc32Algorithm"/> class. 
+		/// Initializes a new instance of the <see cref="Crc32Algorithm"/> class.
 		/// </summary>
 		/// <param name="isBigEndian">Should return bytes result as big endian or little endian</param>
 		// Crc32 by dariogriffo uses big endian, so, we need to be compatible and return big endian as default
@@ -72,6 +75,23 @@ namespace Force.Crc32
 			return AppendInternal(initial, input, 0, input.Length);
 		}
 
+#if NETCORE20 || NETCORE30
+        /// <summary>
+        /// Computes CRC-32 from multiple buffers.
+        /// Call this method multiple times to chain multiple buffers.
+        /// </summary>
+        /// <param name="initial">
+        /// Initial CRC value for the algorithm. It is zero for the first buffer.
+        /// Subsequent buffers should have their initial value set to CRC value returned by previous call to this method.
+        /// </param>
+        /// <param name="input">Input buffer containing data to be checksummed.</param>
+        /// <returns>Accumulated CRC-32 of all buffers processed so far.</returns>
+        public static uint Append(uint initial, ReadOnlySpan<byte> input)
+        {
+            return AppendInternal(initial, input);
+        }
+#endif
+
 		/// <summary>
 		/// Computes CRC-32 from input buffer.
 		/// </summary>
@@ -93,6 +113,18 @@ namespace Force.Crc32
 		{
 			return Append(0, input);
 		}
+
+#if NETCORE20 || NETCORE30
+        /// <summary>
+        /// Computes CRC-32 from input buffer.
+        /// </summary>
+        /// <param name="input">Input buffer with data to be checksummed.</param>
+        /// <returns>CRC-32 of the data in the buffer.</returns>
+        public static uint Compute(ReadOnlySpan<byte> input)
+        {
+            return Append(0, input);
+        }
+#endif
 
 		/// <summary>
 		/// Computes CRC-32 from input buffer and writes it after end of data (buffer should have 4 bytes reserved space for it). Can be used in conjunction with <see cref="IsValidWithCrcAtEnd(byte[],int,int)"/>
@@ -162,12 +194,22 @@ namespace Force.Crc32
 		/// Appends CRC-32 from given buffer
 		/// </summary>
 		protected override void HashCore(byte[] input, int offset, int length)
-		{
+        {
 			_currentCrc = AppendInternal(_currentCrc, input, offset, length);
 		}
 
-		/// <summary>
-		/// Computes CRC-32 from <see cref="HashCore"/>
+#if NETCORE30
+        /// <summary>
+        /// Appends CRC-32 from given buffer
+        /// </summary>
+        protected override void HashCore(ReadOnlySpan<byte> source)
+        {
+            _currentCrc = AppendInternal(_currentCrc, source);
+        }
+#endif
+
+        /// <summary>
+		/// Computes CRC-32 from <see cref="HashCore(byte[], int, int)"/>
 		/// </summary>
 		protected override byte[] HashFinal()
 		{
@@ -176,6 +218,32 @@ namespace Force.Crc32
 			else
 				return new[] { (byte)_currentCrc, (byte)(_currentCrc >> 8), (byte)(_currentCrc >> 16), (byte)(_currentCrc >> 24) };
 		}
+
+#if NETCORE30
+        /// <summary>
+		/// Computes CRC-32 from <see cref="HashCore(ReadOnlySpan{byte})"/>
+		/// </summary>
+		protected override bool TryHashFinal(Span<byte> destination, out int bytesWritten)
+		{
+            if (destination.Length < 4)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            if (_isBigEndian)
+            {
+                BinaryPrimitives.WriteUInt32BigEndian(destination, _currentCrc);
+            }
+            else
+            {
+                BinaryPrimitives.WriteUInt32LittleEndian(destination, _currentCrc);
+            }
+
+            bytesWritten = 4;
+            return true;
+        }
+#endif
 
 		private static readonly SafeProxy _proxy = new SafeProxy();
 
@@ -188,5 +256,17 @@ namespace Force.Crc32
 			else
 				return initial;
 		}
+
+#if NETCORE20 || NETCORE30
+        private static uint AppendInternal(uint initial, ReadOnlySpan<byte> input)
+        {
+            if (input.Length > 0)
+            {
+                return _proxy.Append(initial, input);
+            }
+            else
+                return initial;
+        }
+#endif
 	}
 }

--- a/Crc32.NET/SafeProxy.cs
+++ b/Crc32.NET/SafeProxy.cs
@@ -1,12 +1,14 @@
 ﻿/* This is .NET safe implementation of Crc32 algorithm.
  * This implementation was investigated as fastest from different variants. It based on Robert Vazan native implementations of Crc32C
  * Also, it is good for x64 and for x86, so, it seems, there is no sense to do 2 different realizations.
- * 
+ *
  * Addition: some speed increase was found with splitting xor to 4 independent blocks. Also, some attempts to optimize unaligned tails was unsuccessfull (JIT limitations?).
- * 
- * 
+ *
+ *
  * Max Vysokikh, 2016-2017
  */
+
+using System;
 
 namespace Force.Crc32
 {
@@ -35,6 +37,7 @@ namespace Force.Crc32
 			}
 		}
 
+#if !NETCORE20 && !NETCORE30
 		public uint Append(uint crc, byte[] input, int offset, int length)
 		{
 			uint crcLocal = uint.MaxValue ^ crc;
@@ -52,9 +55,9 @@ namespace Force.Crc32
 					^ table[(5 * 256) + input[offset + 10]]
 					^ table[(4 * 256) + input[offset + 11]];
 
-				var c = table[(11 * 256) + input[offset + 4]] 
-					^ table[(10 * 256) + input[offset + 5]] 
-					^ table[(9 * 256) + input[offset + 6]] 
+				var c = table[(11 * 256) + input[offset + 4]]
+					^ table[(10 * 256) + input[offset + 5]]
+					^ table[(9 * 256) + input[offset + 6]]
 					^ table[(8 * 256) + input[offset + 7]];
 
 				var d = table[(15 * 256) + ((byte)crcLocal ^ input[offset])]
@@ -72,5 +75,49 @@ namespace Force.Crc32
 
 			return crcLocal ^ uint.MaxValue;
 		}
+#else
+        public uint Append(uint crc, byte[] input, int offset, int length)
+        {
+            return Append(crc, input.AsSpan(offset, length));
+        }
+
+        public uint Append(uint crc, ReadOnlySpan<byte> input)
+		{
+			uint crcLocal = uint.MaxValue ^ crc;
+
+			uint[] table = _table;
+			while (input.Length >= 16)
+			{
+				var a = table[(3 * 256) + input[12]]
+					^ table[(2 * 256) + input[13]]
+					^ table[(1 * 256) + input[14]]
+					^ table[(0 * 256) + input[15]];
+
+				var b = table[(7 * 256) + input[8]]
+					^ table[(6 * 256) + input[9]]
+					^ table[(5 * 256) + input[10]]
+					^ table[(4 * 256) + input[11]];
+
+				var c = table[(11 * 256) + input[4]]
+					^ table[(10 * 256) + input[5]]
+					^ table[(9 * 256) + input[6]]
+					^ table[(8 * 256) + input[7]];
+
+				var d = table[(15 * 256) + ((byte)crcLocal ^ input[0])]
+					^ table[(14 * 256) + ((byte)(crcLocal >> 8) ^ input[1])]
+					^ table[(13 * 256) + ((byte)(crcLocal >> 16) ^ input[2])]
+					^ table[(12 * 256) + ((crcLocal >> 24) ^ input[3])];
+
+				crcLocal = d ^ c ^ b ^ a;
+                input = input.Slice(16);
+            }
+
+            var i = 0;
+			while (i < input.Length)
+				crcLocal = table[(byte)(crcLocal ^ input[i++])] ^ crcLocal >> 8;
+
+			return crcLocal ^ uint.MaxValue;
+		}
+#endif
 	}
 }


### PR DESCRIPTION
The addition of Span<T> in .NET Core 2.1 can offer some performance
improvements moving through the array in SafeProxy by reducing the
number of arithmetic operations.

.NET Core 3.0 also adds Span<byte> based overloads to HashAlgorithm
which can further improve performance if explicitly supported. If not
supported, any requests to the Span<byte> overloads are copied to an
array before processing.

A BenchmarkDotNet project was also added to assist with benchmarking.

Test results across several target frameworks comparing the pre and post
change performance against a 65536 byte array. These metrics are for
calls in via the array overloads, not the Span<byte> overloads. They
show an approximately 25% reduction in runtime on .NET Core 2.1 and 3.1.

| Method |       Runtime |  Size |     Mean |    Error |   StdDev | Ratio | Rank |
|------- |-------------- |------ |---------:|---------:|---------:|------:|-----:|
|  Array |    .NET 4.6.1 | 65536 | 48.08 us | 0.192 us | 0.170 us |  1.00 |    1 |
|   Span |    .NET 4.6.1 | 65536 | 47.87 us | 0.169 us | 0.150 us |  1.00 |    1 |
|        |               |       |          |          |          |       |      |
|  Array | .NET Core 2.1 | 65536 | 48.99 us | 0.260 us | 0.217 us |  1.00 |    2 |
|   Span | .NET Core 2.1 | 65536 | 37.02 us | 0.261 us | 0.218 us |  0.76 |    1 |
|        |               |       |          |          |          |       |      |
|  Array | .NET Core 3.1 | 65536 | 50.01 us | 0.335 us | 0.297 us |  1.00 |    2 |
|   Span | .NET Core 3.1 | 65536 | 37.04 us | 0.218 us | 0.204 us |  0.74 |    1 |