### PR TITLE
Hardware intrinsics

### DIFF
--- a/Crc32.NET.Tests/BytePatternsTest.cs
+++ b/Crc32.NET.Tests/BytePatternsTest.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCORE
+﻿#if NETFRAMEWORK
 using System;
 using System.Linq;
 using Force.Crc32.Tests.Crc32Implementations;

--- a/Crc32.NET.Tests/Crc32.NET.Tests.Core.csproj
+++ b/Crc32.NET.Tests/Crc32.NET.Tests.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0;net461;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net461;net5.0;net6.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>Crc32.NET.Tests</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -13,34 +13,22 @@
     <ProjectReference Include="..\Crc32.NET\Crc32.NET.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="K4os.Hash.Crc" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170106-08" />
     <PackageReference Include="CRC32C.Standard" Version="1.0.0" />
-    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="Crc32" Version="1.1.0" />
+    <PackageReference Include="K4os.Hash.Crc" Version="1.1.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0'">
-    <PackageReference Include="NETStandard.Library" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461'">
     <PackageReference Include="CH.Crc32" Version="1.0" />
-    <PackageReference Include="Crc32" Version="1.0.0" />
-    <PackageReference Include="Crc32C.NET" Version="1.0.5.0" />
+    <PackageReference Include="Crc32" Version="1.1.0" />
+    <PackageReference Include="Crc32C.NET" Version="1.0.5" />
     <PackageReference Include="Dexiom.QuickCrc32" Version="1.0.3" />
-    <PackageReference Include="Klinkby.Checksum" Version="1.0.2.1" />
-    <PackageReference Include="System.Data.HashFunction.Core" Version="1.8.2.2" />
-    <PackageReference Include="System.Data.HashFunction.CRC" Version="1.8.2.2" />
-    <PackageReference Include="System.Data.HashFunction.Interfaces" Version="1.0.0.2" />
+    <PackageReference Include="Klinkby.Checksum" Version="1.0.2" />
+    <PackageReference Include="System.Data.HashFunction.Core" Version="2.0.0" />
+    <PackageReference Include="System.Data.HashFunction.CRC" Version="2.0.0" />
+    <PackageReference Include="System.Data.HashFunction.Interfaces" Version="2.0.0" />
     <PackageReference Include="CRC32C.Standard" Version="1.0.0" />
-    <!--PackageReference Include="NUnit" Version="3.6.0" /-->
   </ItemGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
-    <DefineConstants>$(DefineConstants);NETCORE;;NETCORE13</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <DefineConstants>$(DefineConstants);NETCORE;NETCORE20</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup>
-    <DefineConstants>$(DefineConstants);COREVERSION</DefineConstants>
-  </PropertyGroup>
 </Project>

--- a/Crc32.NET.Tests/Crc32.NET.Tests.Core.csproj
+++ b/Crc32.NET.Tests/Crc32.NET.Tests.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0;net461;net5.0;net6.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>Crc32.NET.Tests</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Crc32.NET.Tests/Crc32.NET.Tests.Core.csproj
+++ b/Crc32.NET.Tests/Crc32.NET.Tests.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>Crc32.NET.Tests</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Crc32.NET.Tests/Crc32Implementations/CH_Crc32_Crc.cs
+++ b/Crc32.NET.Tests/Crc32Implementations/CH_Crc32_Crc.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCORE
+﻿#if NETFRAMEWORK
 
 namespace Force.Crc32.Tests.Crc32Implementations
 {

--- a/Crc32.NET.Tests/Crc32Implementations/Crc32C_Crc32CAlgorithm.cs
+++ b/Crc32.NET.Tests/Crc32Implementations/Crc32C_Crc32CAlgorithm.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCORE
+﻿#if NETFRAMEWORK
 namespace Force.Crc32.Tests.Crc32Implementations
 {
 	public class Crc32C_Crc32CAlgorithm : CrcCalculator

--- a/Crc32.NET.Tests/Crc32Implementations/Crc32C_Standard.cs
+++ b/Crc32.NET.Tests/Crc32Implementations/Crc32C_Standard.cs
@@ -1,5 +1,4 @@
-﻿#if !NETFRAMEWORK
-namespace Force.Crc32.Tests.Crc32Implementations
+﻿namespace Force.Crc32.Tests.Crc32Implementations
 {
 	public class Crc32C_Standard : CrcCalculator
 	{
@@ -15,4 +14,3 @@ namespace Force.Crc32.Tests.Crc32Implementations
 		}
 	}
 }
-#endif

--- a/Crc32.NET.Tests/Crc32Implementations/Crc32C_Standard.cs
+++ b/Crc32.NET.Tests/Crc32Implementations/Crc32C_Standard.cs
@@ -1,4 +1,4 @@
-﻿#if NETCORE
+﻿#if !NETFRAMEWORK
 namespace Force.Crc32.Tests.Crc32Implementations
 {
 	public class Crc32C_Standard : CrcCalculator

--- a/Crc32.NET.Tests/Crc32Implementations/Crc32_Crc32Algorithm.cs
+++ b/Crc32.NET.Tests/Crc32Implementations/Crc32_Crc32Algorithm.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCORE
+﻿#if NETFRAMEWORK
 using Crc = Crc32.Crc32Algorithm;
 
 namespace Force.Crc32.Tests.Crc32Implementations

--- a/Crc32.NET.Tests/Crc32Implementations/Crc32_Crc32Algorithm.cs
+++ b/Crc32.NET.Tests/Crc32Implementations/Crc32_Crc32Algorithm.cs
@@ -1,5 +1,4 @@
-﻿#if NETFRAMEWORK
-using Crc = Crc32.Crc32Algorithm;
+﻿using Crc = Crc32.Crc32Algorithm;
 
 namespace Force.Crc32.Tests.Crc32Implementations
 {
@@ -15,4 +14,3 @@ namespace Force.Crc32.Tests.Crc32Implementations
 		}
 	}
 }
-#endif

--- a/Crc32.NET.Tests/Crc32Implementations/CrcCalculator.cs
+++ b/Crc32.NET.Tests/Crc32Implementations/CrcCalculator.cs
@@ -2,12 +2,15 @@
 {
 	public abstract class CrcCalculator
 	{
-		protected CrcCalculator(string name)
+		protected CrcCalculator(string name, bool isSupported = true)
 		{
 			Name = name;
+			IsSupported = isSupported;
 		}
 
 		public string Name { get; private set; }
+
+		public bool IsSupported { get; private set; }
 
 		public abstract uint Calculate(byte[] data);
 	}

--- a/Crc32.NET.Tests/Crc32Implementations/Dexiom_Quick_Crc32.cs
+++ b/Crc32.NET.Tests/Crc32Implementations/Dexiom_Quick_Crc32.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCORE
+﻿#if NETFRAMEWORK
 namespace Force.Crc32.Tests.Crc32Implementations
 {
 	public class Dexiom_Quick_Crc32 : CrcCalculator

--- a/Crc32.NET.Tests/Crc32Implementations/Force_Intrinsics_Crc32_Crc32Algorithm.cs
+++ b/Crc32.NET.Tests/Crc32Implementations/Force_Intrinsics_Crc32_Crc32Algorithm.cs
@@ -1,0 +1,17 @@
+namespace Force.Crc32.Tests.Crc32Implementations
+{
+	using Algorithm = Force.Crc32.Intrinsics.Crc32Algorithm;
+
+	public class Force_Intrinsics_Crc32_Crc32Algorithm : CrcCalculator
+	{
+		public Force_Intrinsics_Crc32_Crc32Algorithm()
+			: base("Force.Crc32.Intrinsics.Crc32Algorithm", Algorithm.IsSupported)
+		{
+		}
+
+		public override uint Calculate(byte[] data)
+		{
+			return Algorithm.Compute(data);
+		}
+	}
+}

--- a/Crc32.NET.Tests/Crc32Implementations/Force_Intrinsics_Crc32_Crc32CAlgorithm.cs
+++ b/Crc32.NET.Tests/Crc32Implementations/Force_Intrinsics_Crc32_Crc32CAlgorithm.cs
@@ -1,0 +1,17 @@
+namespace Force.Crc32.Tests.Crc32Implementations
+{
+	using Algorithm = Force.Crc32.Intrinsics.Crc32CAlgorithm;
+	
+	public class Force_Intrinsics_Crc32_Crc32CAlgorithm : CrcCalculator
+	{
+		public Force_Intrinsics_Crc32_Crc32CAlgorithm()
+			: base("Force.Crc32.Intrinsics.Crc32CAlgorithm", Algorithm.IsSupported)
+		{
+		}
+
+		public override uint Calculate(byte[] data)
+		{
+			return Algorithm.Compute(data);
+		}
+	}
+}

--- a/Crc32.NET.Tests/Crc32Implementations/K4os_Hash_Crc.cs
+++ b/Crc32.NET.Tests/Crc32Implementations/K4os_Hash_Crc.cs
@@ -1,5 +1,4 @@
-﻿#if COREVERSION
-namespace Force.Crc32.Tests.Crc32Implementations
+﻿namespace Force.Crc32.Tests.Crc32Implementations
 {
 	public class K4os_Hash_Crc : CrcCalculator
 	{
@@ -13,4 +12,3 @@ namespace Force.Crc32.Tests.Crc32Implementations
 		}
 	}
 }
-#endif

--- a/Crc32.NET.Tests/Crc32Implementations/Klinkby_Checkum_Crc32.cs
+++ b/Crc32.NET.Tests/Crc32Implementations/Klinkby_Checkum_Crc32.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCORE
+﻿#if NETFRAMEWORK
 namespace Force.Crc32.Tests.Crc32Implementations
 {
 	public class Klinkby_Checkum_Crc32 : CrcCalculator

--- a/Crc32.NET.Tests/Crc32Implementations/System_Data_HashFunction_CRC.cs
+++ b/Crc32.NET.Tests/Crc32Implementations/System_Data_HashFunction_CRC.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCORE
+﻿#if NETFRAMEWORK
 using System;
 using System.Data.HashFunction;
 

--- a/Crc32.NET.Tests/PerformanceTest.cs
+++ b/Crc32.NET.Tests/PerformanceTest.cs
@@ -8,7 +8,7 @@ namespace Force.Crc32.Tests
 	[TestFixture]
 	public class PerformanceTest
 	{
-#if !NETCORE
+#if NETFRAMEWORK
 		[Test]
 		public void ThroughputCHCrc32_By_tanglebones()
 		{
@@ -70,7 +70,23 @@ namespace Force.Crc32.Tests
 			Calculate(new Force_Crc32_Crc32CAlgorithm());
 		}
 
-#if COREVERSION && !NETCORE13
+#if NETCOREAPP3_0_OR_GREATER
+		[Test]
+		public void ThroughputCrc32C_By_Me_Intrinsics()
+		{
+			Calculate(new Force_Intrinsics_Crc32_Crc32CAlgorithm());
+		}
+#endif
+
+#if NET5_0_OR_GREATER
+		[Test]
+		public void ThroughputCrc32_By_Me_Intrinsics()
+		{
+			Calculate(new Force_Intrinsics_Crc32_Crc32Algorithm());
+		}
+#endif
+
+#if COREVERSION && NETFRAMEWORK13
 		[Test]
 		public void ThroughputCrc32C_By_K4os_Hash_Crc()
 		{
@@ -80,6 +96,11 @@ namespace Force.Crc32.Tests
 
 		private void Calculate(CrcCalculator implementation, int size = 65536)
 		{
+			if(!implementation.IsSupported)
+			{
+				return;
+			}
+
 			var data = new byte[size];
 			var random = new Random();
 			random.NextBytes(data);

--- a/Crc32.NET.Tests/PerformanceTest.cs
+++ b/Crc32.NET.Tests/PerformanceTest.cs
@@ -22,12 +22,6 @@ namespace Force.Crc32.Tests
 		}
 
 		[Test]
-		public void ThroughputCrc32_By_dariogriffo()
-		{
-			Calculate(new Crc32_Crc32Algorithm());
-		}
-
-		[Test]
 		public void ThroughputCrc32_By_Data_HashFunction_Crc()
 		{
 			Calculate(new System_Data_HashFunction_CRC());
@@ -44,14 +38,25 @@ namespace Force.Crc32.Tests
 		{
 			Calculate(new Crc32C_Crc32CAlgorithm());
 		}
-#else
+#endif
 		[Test]
 		public void ThroughputCrc32C_Standard()
 		{
 			Calculate(new Crc32C_Standard());
 		}
-#endif
-	
+
+		[Test]
+		public void ThroughputCrc32_By_dariogriffo()
+		{
+			Calculate(new Crc32_Crc32Algorithm());
+		}
+
+		[Test]
+		public void ThroughputCrc32C_By_K4os_Hash_Crc()
+		{
+			Calculate(new K4os_Hash_Crc());
+		}
+
 		[Test]
 		public void ThroughputCrc32_By_Me()
 		{
@@ -83,14 +88,6 @@ namespace Force.Crc32.Tests
 		public void ThroughputCrc32_By_Me_Intrinsics()
 		{
 			Calculate(new Force_Intrinsics_Crc32_Crc32Algorithm());
-		}
-#endif
-
-#if COREVERSION && NETFRAMEWORK13
-		[Test]
-		public void ThroughputCrc32C_By_K4os_Hash_Crc()
-		{
-			Calculate(new K4os_Hash_Crc());
 		}
 #endif
 

--- a/Crc32.NET.Tests/Program.cs
+++ b/Crc32.NET.Tests/Program.cs
@@ -6,16 +6,14 @@
 		{
 			var pt = new PerformanceTest();
 #if NETFRAMEWORK
-			pt.ThroughputCrc32_By_dariogriffo();
 			pt.ThroughputCHCrc32_By_tanglebones();
             pt.ThroughputKlinkby_Checksum();
 			pt.ThroughputCrc32_By_Data_HashFunction_Crc();
 			pt.ThroughputCrc32_By_Me();
 			pt.ThroughputCrc32_By_Dexiom();
-#if COREVERSION
-			pt.ThroughputCrc32C_By_K4os_Hash_Crc();
 #endif
-#else
+			pt.ThroughputCrc32_By_dariogriffo();
+			pt.ThroughputCrc32C_By_K4os_Hash_Crc();
 			pt.ThroughputCrc32C_Standard();
 			pt.ThroughputCrc32C_By_Me();
 			pt.ThroughputCrc32_By_Me();
@@ -24,7 +22,6 @@
 #endif
 #if NET5_0_OR_GREATER
 			pt.ThroughputCrc32_By_Me_Intrinsics();
-#endif
 #endif
         }
     }

--- a/Crc32.NET.Tests/Program.cs
+++ b/Crc32.NET.Tests/Program.cs
@@ -5,7 +5,7 @@
 		public static void Main()
 		{
 			var pt = new PerformanceTest();
-#if !NETCORE
+#if NETFRAMEWORK
 			pt.ThroughputCrc32_By_dariogriffo();
 			pt.ThroughputCHCrc32_By_tanglebones();
             pt.ThroughputKlinkby_Checksum();
@@ -19,8 +19,13 @@
 			pt.ThroughputCrc32C_Standard();
 			pt.ThroughputCrc32C_By_Me();
 			pt.ThroughputCrc32_By_Me();
+#if NETCOREAPP3_0_OR_GREATER
+			pt.ThroughputCrc32C_By_Me_Intrinsics();
 #endif
-
+#if NET5_0_OR_GREATER
+			pt.ThroughputCrc32_By_Me_Intrinsics();
+#endif
+#endif
         }
     }
 }

--- a/Crc32.NET/Crc32.NET.Core.csproj
+++ b/Crc32.NET/Crc32.NET.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <VersionPrefix>1.3.0</VersionPrefix>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;net20;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Crc32.NET</AssemblyName>
     <!--DelaySign>true</DelaySign>

--- a/Crc32.NET/Crc32.NET.Core.csproj
+++ b/Crc32.NET/Crc32.NET.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>1.2.1</VersionPrefix>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;net20</TargetFrameworks>
+    <VersionPrefix>1.3.0</VersionPrefix>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net20;net5.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Crc32.NET</AssemblyName>
     <!--DelaySign>true</DelaySign>

--- a/Crc32.NET/Crc32.NET.Core.csproj
+++ b/Crc32.NET/Crc32.NET.Core.csproj
@@ -12,6 +12,7 @@
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">2.0.0</NetStandardImplicitPackageVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'BuildCore' ">
     <DelaySign>true</DelaySign>

--- a/Crc32.NET/Intrinsics/Crc32Algorithm.cs
+++ b/Crc32.NET/Intrinsics/Crc32Algorithm.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Security.Cryptography;
+
+#if NET5_0_OR_GREATER
+using Arm32 = System.Runtime.Intrinsics.Arm.Crc32;
+using Arm64 = System.Runtime.Intrinsics.Arm.Crc32.Arm64;
+#endif
+
+namespace Force.Crc32.Intrinsics
+{
+    /// <summary>
+    /// The hardware implementation of the CRC32-C polynomial 
+    /// implemented on Intel CPUs supporting SSE4.2.
+    /// </summary>
+    public class Crc32Algorithm : HashAlgorithm
+    {
+        /// <summary>
+        /// the current CRC value, bit-flipped
+        /// </summary>
+        private uint _crc;
+
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        public Crc32Algorithm()
+        {
+            // The size, in bits, of the computed hash code.
+            this.HashSizeValue = 32;
+            this.Reset();
+        }
+
+        /// <summary>Initializes an implementation of the <see cref="T:System.Security.Cryptography.HashAlgorithm"></see> class.</summary>
+        public override void Initialize()
+        {
+            this.Reset();
+        }
+
+		/// <summary>
+		/// Computes CRC-32C from input buffer.
+		/// </summary>
+		/// <param name="input">Input buffer containing data to be checksummed.</param>
+		/// <returns>CRC-32C of the buffer.</returns>
+        public static uint Compute(byte[] input)
+		{
+			var algo = new Crc32Algorithm();
+            algo.HashCore(input);
+            return ~algo._crc;
+		}
+
+
+        /// <summary>When overridden in a derived class, routes data written to the object into the hash algorithm for computing the hash.</summary>
+        /// <param name="array">The input to compute the hash code for.</param>
+        /// <param name="ibStart">The offset into the byte array from which to begin using data.</param>
+        /// <param name="cbSize">The number of bytes in the byte array to use as data.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            switch(Platform)
+            {
+                case Platform.Arm64:
+                case Platform.Arm32:
+                    HashCoreArm(array, ibStart, cbSize);
+                    break;
+                default:
+                    throw new NotSupportedException("CRC32 intrinsics are not suppored on this platform");
+            }
+        }
+
+        /// <summary>When overridden in a derived class, finalizes the hash computation after the last data is processed by the cryptographic stream object.</summary>
+        /// <returns>The computed hash code.</returns>
+        protected override byte[] HashFinal()
+        {
+            uint outputCrcValue = ~_crc;
+
+            return BitConverter.GetBytes(outputCrcValue);
+        }
+
+
+        private void HashCoreArm(byte[] array, int ibStart, int cbSize)
+        {
+#if NET5_0_OR_GREATER
+            if (Platform == Platform.Arm64)
+            {
+                while (cbSize >= 8)
+                {
+                    _crc = Arm64.ComputeCrc32(_crc, BitConverter.ToUInt64(array, ibStart));
+                    ibStart += 8;
+                    cbSize -= 8;
+                }
+            }
+
+            while (cbSize > 0)
+            {
+                _crc = Arm32.ComputeCrc32(_crc, array[ibStart]);
+                ibStart++;
+                cbSize--;
+            }
+#endif
+        }
+
+        private static Platform Platform =>
+#if NET5_0_OR_GREATER
+            Arm64.IsSupported ? Platform.Arm64 :
+            Arm32.IsSupported ? Platform.Arm32 :
+#endif
+            Platform.Unsupported;
+
+        private void Reset()
+        {
+            _crc = uint.MaxValue;
+        }
+    }
+}

--- a/Crc32.NET/Intrinsics/Crc32CAlgorithm.cs
+++ b/Crc32.NET/Intrinsics/Crc32CAlgorithm.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Security.Cryptography;
+
+#if NETCOREAPP3_0_OR_GREATER
+using X86 = System.Runtime.Intrinsics.X86.Sse42;
+using X64 = System.Runtime.Intrinsics.X86.Sse42.X64;
+#endif
+
+#if NET5_0_OR_GREATER
+using Arm32 = System.Runtime.Intrinsics.Arm.Crc32;
+using Arm64 = System.Runtime.Intrinsics.Arm.Crc32.Arm64;
+#endif
+
+namespace Force.Crc32.Intrinsics
+{
+    /// <summary>
+    /// The hardware implementation of the CRC32-C polynomial 
+    /// implemented on Intel CPUs supporting SSE4.2.
+    /// </summary>
+    public class Crc32CAlgorithm : HashAlgorithm
+    {
+        /// <summary>
+        /// the current CRC value, bit-flipped
+        /// </summary>
+        private uint _crc;
+
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        public Crc32CAlgorithm()
+        {
+            // The size, in bits, of the computed hash code.
+            this.HashSizeValue = 32;
+            this.Reset();
+        }
+
+        /// <summary>Initializes an implementation of the <see cref="T:System.Security.Cryptography.HashAlgorithm"></see> class.</summary>
+        public override void Initialize()
+        {
+            this.Reset();
+        }
+
+		/// <summary>
+		/// Computes CRC-32C from input buffer.
+		/// </summary>
+		/// <param name="input">Input buffer containing data to be checksummed.</param>
+		/// <returns>CRC-32C of the buffer.</returns>
+        public static uint Compute(byte[] input)
+		{
+			var algo = new Crc32CAlgorithm();
+            algo.HashCore(input);
+            return ~algo._crc;
+		}
+
+
+        /// <summary>When overridden in a derived class, routes data written to the object into the hash algorithm for computing the hash.</summary>
+        /// <param name="array">The input to compute the hash code for.</param>
+        /// <param name="ibStart">The offset into the byte array from which to begin using data.</param>
+        /// <param name="cbSize">The number of bytes in the byte array to use as data.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            switch(Platform)
+            {
+                case Platform.X64:
+                case Platform.X86:
+                    HashCoreX86(array, ibStart, cbSize);
+                    break;
+                case Platform.Arm64:
+                case Platform.Arm32:
+                    HashCoreArm(array, ibStart, cbSize);
+                    break;
+                default:
+                    throw new NotSupportedException("CRC32 intrinsics are not suppored on this platform");
+            }
+        }
+
+        private void HashCoreX86(byte[] array, int ibStart, int cbSize)
+        {
+#if NETCOREAPP3_0_OR_GREATER
+            if (Platform == Platform.X64)
+            {
+                ulong crc = _crc;
+                while (cbSize >= 8)
+                {
+                    crc = X64.Crc32(crc, BitConverter.ToUInt64(array, ibStart));
+                    ibStart += 8;
+                    cbSize -= 8;
+                }
+                _crc = (uint)crc;
+            }
+
+            while (cbSize > 0)
+            {
+                _crc = X86.Crc32(_crc, array[ibStart]);
+                ibStart++;
+                cbSize--;
+            }
+#endif
+        }
+
+        private void HashCoreArm(byte[] array, int ibStart, int cbSize)
+        {
+#if NET5_0_OR_GREATER
+            if (Platform == Platform.Arm64)
+            {
+                while (cbSize >= 8)
+                {
+                    _crc = Arm64.ComputeCrc32C(_crc, BitConverter.ToUInt64(array, ibStart));
+                    ibStart += 8;
+                    cbSize -= 8;
+                }
+            }
+
+            while (cbSize > 0)
+            {
+                _crc = Arm32.ComputeCrc32C(_crc, array[ibStart]);
+                ibStart++;
+                cbSize--;
+            }
+#endif
+        }
+
+
+        /// <summary>When overridden in a derived class, finalizes the hash computation after the last data is processed by the cryptographic stream object.</summary>
+        /// <returns>The computed hash code.</returns>
+        protected override byte[] HashFinal()
+        {
+            uint outputCrcValue = ~_crc;
+
+            return BitConverter.GetBytes(outputCrcValue);
+        }
+
+        private static Platform Platform =>
+#if NETCOREAPP3_0_OR_GREATER
+            X64.IsSupported ? Platform.X64 :
+            X86.IsSupported ? Platform.X86 :
+#endif
+#if NET5_0_OR_GREATER
+            Arm64.IsSupported ? Platform.Arm64 :
+            Arm32.IsSupported ? Platform.Arm32 :
+#endif
+            Platform.Unsupported;
+
+        private void Reset()
+        {
+            _crc = uint.MaxValue;
+        }
+    }
+}

--- a/Crc32.NET/Intrinsics/Crc32CAlgorithm.cs
+++ b/Crc32.NET/Intrinsics/Crc32CAlgorithm.cs
@@ -1,21 +1,21 @@
 using System;
 using System.Security.Cryptography;
-
 #if NETCOREAPP3_0_OR_GREATER
 using X86 = System.Runtime.Intrinsics.X86.Sse42;
 using X64 = System.Runtime.Intrinsics.X86.Sse42.X64;
 #endif
-
 #if NET5_0_OR_GREATER
 using Arm32 = System.Runtime.Intrinsics.Arm.Crc32;
 using Arm64 = System.Runtime.Intrinsics.Arm.Crc32.Arm64;
+using System.Runtime.InteropServices;
 #endif
 
 namespace Force.Crc32.Intrinsics
 {
     /// <summary>
-    /// The hardware implementation of the CRC32-C polynomial 
-    /// implemented on Intel CPUs supporting SSE4.2.
+    /// The hardware implementation of the CRC32C polynomial supported by:
+    /// - Intel CPUs supporting SSE4.2
+    /// - ARM CPUs since ARMv8.1 
     /// </summary>
     public class Crc32CAlgorithm : HashAlgorithm
     {
@@ -29,37 +29,58 @@ namespace Force.Crc32.Intrinsics
         /// </summary>
         public Crc32CAlgorithm()
         {
-            // The size, in bits, of the computed hash code.
+#if NETSTANDARD2_0_OR_GREATER
             this.HashSizeValue = 32;
+#endif
             this.Reset();
         }
 
-        /// <summary>Initializes an implementation of the <see cref="T:System.Security.Cryptography.HashAlgorithm"></see> class.</summary>
+        /// <summary>
+        /// Check if the algorithm is supported on the current CPU
+        /// </summary>
+        public static bool IsSupported => Platform != Platform.Unsupported;
+
+        /// <summary>
+        /// Initializes an implementation of the <see cref="T:System.Security.Cryptography.HashAlgorithm" /> class
+        /// </summary>
         public override void Initialize()
         {
             this.Reset();
         }
 
-		/// <summary>
-		/// Computes CRC-32C from input buffer.
-		/// </summary>
-		/// <param name="input">Input buffer containing data to be checksummed.</param>
-		/// <returns>CRC-32C of the buffer.</returns>
+        /// <summary>
+        /// Computes CRC32C from input buffer.
+        /// </summary>
+        /// <param name="input">Input buffer with data to be checksummed.</param>
+        /// <returns>CRC32C of the data in the buffer.</returns>
         public static uint Compute(byte[] input)
-		{
-			var algo = new Crc32CAlgorithm();
-            algo.HashCore(input);
+        {
+            return Compute(input, 0, input.Length);
+        }
+
+        /// <summary>
+        /// Computes CRC32C from input buffer.
+        /// </summary>
+        /// <param name="input">Input buffer with data to be checksummed.</param>
+        /// <param name="offset">Offset of the input data within the buffer.</param>
+        /// <param name="length">Length of the input data in the buffer.</param>
+        /// <returns>CRC32C of the data in the buffer.</returns>
+        public static uint Compute(byte[] input, int offset, int length)
+        {
+            var algo = new Crc32CAlgorithm();
+            algo.HashCore(input, offset, length);
             return ~algo._crc;
-		}
+        }
 
-
-        /// <summary>When overridden in a derived class, routes data written to the object into the hash algorithm for computing the hash.</summary>
+        /// <summary>
+        /// When overridden in a derived class, routes data written to the object into the hash algorithm for computing the hash
+        /// </summary>
         /// <param name="array">The input to compute the hash code for.</param>
         /// <param name="ibStart">The offset into the byte array from which to begin using data.</param>
         /// <param name="cbSize">The number of bytes in the byte array to use as data.</param>
         protected override void HashCore(byte[] array, int ibStart, int cbSize)
         {
-            switch(Platform)
+            switch (Platform)
             {
                 case Platform.X64:
                 case Platform.X86:
@@ -74,26 +95,54 @@ namespace Force.Crc32.Intrinsics
             }
         }
 
+        /// <summary>
+        /// When overridden in a derived class, finalizes the hash computation after the last data is processed by the cryptographic stream object.
+        /// </summary>
+        /// <returns>The computed hash code.</returns>
+        protected override byte[] HashFinal()
+        {
+            return BitConverter.GetBytes(~_crc);
+        }
+
         private void HashCoreX86(byte[] array, int ibStart, int cbSize)
         {
 #if NETCOREAPP3_0_OR_GREATER
-            if (Platform == Platform.X64)
+            var span = new ReadOnlySpan<byte>(array, ibStart, cbSize);
+
+            if (Platform == Platform.X64 && span.Length > 0)
             {
-                ulong crc = _crc;
-                while (cbSize >= 8)
+                unsafe
                 {
-                    crc = X64.Crc32(crc, BitConverter.ToUInt64(array, ibStart));
-                    ibStart += 8;
-                    cbSize -= 8;
+                    fixed(byte* start = &span[0])
+                    {
+                        ulong* current = (ulong*)start;
+                        ulong* end = current + span.Length / sizeof(ulong);
+                        ulong crc = _crc;
+                        while (current < end)
+                        {
+                            crc = X64.Crc32(crc, *current++);
+                        }
+                        _crc = (uint)crc;
+
+                        span = new ReadOnlySpan<byte>((byte*)current, span.Length % sizeof(ulong));
+                    }
                 }
-                _crc = (uint)crc;
             }
 
-            while (cbSize > 0)
+            if(span.Length > 0)
             {
-                _crc = X86.Crc32(_crc, array[ibStart]);
-                ibStart++;
-                cbSize--;
+                unsafe
+                {
+                    fixed(byte* start = &span[0])
+                    {
+                        byte* current = start;
+                        byte* end = current + span.Length;
+                        while (current < end)
+                        {
+                            _crc = X86.Crc32(_crc, *current++);
+                        }
+                    }
+                }
             }
 #endif
         }
@@ -101,33 +150,42 @@ namespace Force.Crc32.Intrinsics
         private void HashCoreArm(byte[] array, int ibStart, int cbSize)
         {
 #if NET5_0_OR_GREATER
-            if (Platform == Platform.Arm64)
+            var span = new ReadOnlySpan<byte>(array, ibStart, cbSize);
+
+            if (Platform == Platform.Arm64 && span.Length > 0)
             {
-                while (cbSize >= 8)
+                unsafe
                 {
-                    _crc = Arm64.ComputeCrc32C(_crc, BitConverter.ToUInt64(array, ibStart));
-                    ibStart += 8;
-                    cbSize -= 8;
+                    fixed(byte* start = &span[0])
+                    {
+                        ulong* current = (ulong*)start;
+                        ulong* end = current + span.Length / sizeof(ulong);
+                        while (current < end)
+                        {
+                            _crc = Arm64.ComputeCrc32C(_crc, *current++);
+                        }
+
+                        span = new ReadOnlySpan<byte>((byte*)current, span.Length % sizeof(ulong));
+                    }
                 }
             }
 
-            while (cbSize > 0)
+            if(span.Length > 0)
             {
-                _crc = Arm32.ComputeCrc32C(_crc, array[ibStart]);
-                ibStart++;
-                cbSize--;
+                unsafe
+                {
+                    fixed(byte* start = &span[0])
+                    {
+                        byte* current = start;
+                        byte* end = current + span.Length;
+                        while (current < end)
+                        {
+                            _crc = Arm32.ComputeCrc32C(_crc, *current++);
+                        }
+                    }
+                }
             }
 #endif
-        }
-
-
-        /// <summary>When overridden in a derived class, finalizes the hash computation after the last data is processed by the cryptographic stream object.</summary>
-        /// <returns>The computed hash code.</returns>
-        protected override byte[] HashFinal()
-        {
-            uint outputCrcValue = ~_crc;
-
-            return BitConverter.GetBytes(outputCrcValue);
         }
 
         private static Platform Platform =>

--- a/Crc32.NET/Intrinsics/Platform.cs
+++ b/Crc32.NET/Intrinsics/Platform.cs
@@ -1,0 +1,19 @@
+namespace Force.Crc32.Intrinsics
+{
+    /// <summary>
+    /// Hardware intrinsics platforms supported by the current CPU
+    /// </summary>
+    public enum Platform
+    {
+        /// Hardware intrinsics are not supported on this CPU
+        Unsupported,
+        /// Intel SSE4.2 hardware instructions
+        X86,
+        /// Intel SSE4.2 x64 hardware instructions
+        X64,
+        /// ARM Crc32 hardware instructions
+        Arm32,
+        /// ARM64 Crc32 hardware instructions
+        Arm64,
+    }
+}


### PR DESCRIPTION
Latest .NET frameworks have better support for hardware-accelerated CRC32 implementations:
- CRC32C polynomial:
  - Intel CPUs supporting SSE4.2
  - ARM CPUs since ARMv8.1  
- CRC32 polynomial:
  - ARM CPUs since ARMv8.1

Note: Arm does support both [CRC32](https://developer.arm.com/documentation/dui0801/g/A32-and-T32-Instructions/CRC32) and [CRC32C](https://developer.arm.com/documentation/dui0801/g/A32-and-T32-Instructions/CRC32C) (since ARMv8.1) as does [System.Runtime.Intrinsics.Arm](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.intrinsics.arm?view=net-5.0) (since .NET 5): [CRC32](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.intrinsics.arm.crc32.arm64.computecrc32) and [CRC32C](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.intrinsics.arm.crc32.arm64.computecrc32c).

Test results (.NET 7):
- Intel (Linux Mint 21.2, 11th Gen Intel Core i7-1165G7 2.80GHz CPU):
  ```text
  Crc32.Crc32Algorithm Throughput: 435.0 MB/s
  K4os.Hash.Crc Throughput: 434.5 MB/s
  Crc32C.Standard Throughput: 1379.8 MB/s
  Force.Crc32.Crc32CAlgorithm Throughput: 1822.1 MB/s
  Force.Crc32.Crc32Algorithm Throughput: 1724.3 MB/s
  Force.Crc32.Intrinsics.Crc32CAlgorithm Throughput: 11116.4 MB/s
  ```
- Arm (Amazon Linux 2, AWS `c7g.large` EC2: AWS Graviton3 CPU):
  ```text
  Crc32.Crc32Algorithm Throughput: 352.8 MB/s
  K4os.Hash.Crc Throughput: 309.6 MB/s
  Crc32C.Standard Throughput: 1113.0 MB/s
  Force.Crc32.Crc32CAlgorithm Throughput: 1692.4 MB/s
  Force.Crc32.Crc32Algorithm Throughput: 1694.0 MB/s
  Force.Crc32.Intrinsics.Crc32CAlgorithm Throughput: 3278.2 MB/s
  Force.Crc32.Intrinsics.Crc32Algorithm Throughput: 3293.3 MB/s
  ```

Fixes #16 